### PR TITLE
Add workflow_dispatch to build action

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -6,6 +6,7 @@ on:
       - trunk
     tags:
       - '**'
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Means that building/publishing a new build is just a click away.