### PR TITLE
Add group and user only if they don't already exist

### DIFF
--- a/root/etc/cont-init.d/10-adduser.sh
+++ b/root/etc/cont-init.d/10-adduser.sh
@@ -25,8 +25,8 @@ set -e
 PUID=${PUID:-1001}
 PGID=${PGID:-1001}
 
-addgroup -g "$PGID" abc
-adduser -u "$PUID" -D -G abc abc
+getent group abc >/dev/null || addgroup -g "$PGID" abc
+id -u abc &>/dev/null || adduser -u "$PUID" -D -G abc abc
 
 echo "
 Initializing container


### PR DESCRIPTION
As I reported in issue https://github.com/JakeWharton/docker-mbsync/issues/12, the container currently fails to start again after the first time because it tries to add the group and user again, which were already added the first time. I've added checks to only attempt to add the group and user if they don't already exist.

Closes #12